### PR TITLE
删除无用代码

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -337,10 +337,6 @@ class TpCache_Plugin implements Typecho_Plugin_Interface
 	public static function needCache($path)
 	{
 	    if(isset($_REQUEST['api'])) return false;
-	    // 用户中心插件不缓存
-		$pattern = '#^/ucenter#i';
-		if (preg_match($pattern, $path)) return false;
-		
 		// 后台数据不缓存
 		$pattern = '#^' . __TYPECHO_ADMIN_DIR__ . '#i';
 		if (preg_match($pattern, $path)) return false;


### PR DESCRIPTION
好像本身就不会缓存插件构建的路由页面，所以这个适配是无用的故删除